### PR TITLE
fix: corrigir erro ao realizar GET com o banco vazio

### DIFF
--- a/src/main/java/com/api/gerenciamento_produtos/controller/ProdutoController.java
+++ b/src/main/java/com/api/gerenciamento_produtos/controller/ProdutoController.java
@@ -29,6 +29,9 @@ public class ProdutoController {
                 .stream()
                 .map(mapper::toDTO)
                 .toList();
+        if (produtos.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
         return ResponseEntity.ok(produtos);
     }
 


### PR DESCRIPTION
Adicionado tratamento no endpoint GET /api/produtos para retornar o status HTTP 204 No Content quando o banco de dados estiver vazio.