### PR TITLE
fix: corrigir erro de mapeamento do ID na entidade Produto

### DIFF
--- a/src/main/java/com/api/gerenciamento_produtos/model/Produto.java
+++ b/src/main/java/com/api/gerenciamento_produtos/model/Produto.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 @NoArgsConstructor
 public class Produto {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID id;
 
     @Column(nullable = false, length = 100)


### PR DESCRIPTION
Alterado o GenerationType do campo id na entidade Produto de IDENTITY para AUTO para corrigir incompatibilidade com o banco de dados H2.